### PR TITLE
Modified FOSMessageExtension.php made all Alias(es) public

### DIFF
--- a/DependencyInjection/FOSMessageExtension.php
+++ b/DependencyInjection/FOSMessageExtension.php
@@ -3,6 +3,7 @@
 namespace FOS\MessageBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -38,19 +39,19 @@ class FOSMessageExtension extends Extension
         $container->setParameter('fos_message.reply_form.model', $config['reply_form']['model']);
         $container->setParameter('fos_message.reply_form.name', $config['reply_form']['name']);
 
-        $container->setAlias('fos_message.message_manager', $config['message_manager']);
-        $container->setAlias('fos_message.thread_manager', $config['thread_manager']);
+        $container->setAlias('fos_message.message_manager', new Alias($config['message_manager'], true));
+        $container->setAlias('fos_message.thread_manager', new Alias($config['thread_manager'], true));
 
-        $container->setAlias('fos_message.sender', $config['sender']);
-        $container->setAlias('fos_message.composer', $config['composer']);
-        $container->setAlias('fos_message.provider', $config['provider']);
-        $container->setAlias('fos_message.participant_provider', $config['participant_provider']);
-        $container->setAlias('fos_message.authorizer', $config['authorizer']);
-        $container->setAlias('fos_message.message_reader', $config['message_reader']);
-        $container->setAlias('fos_message.thread_reader', $config['thread_reader']);
-        $container->setAlias('fos_message.deleter', $config['deleter']);
-        $container->setAlias('fos_message.spam_detector', $config['spam_detector']);
-        $container->setAlias('fos_message.twig_extension', $config['twig_extension']);
+        $container->setAlias('fos_message.sender', new Alias($config['sender'], true));
+        $container->setAlias('fos_message.composer', new Alias($config['composer'], true));
+        $container->setAlias('fos_message.provider', new Alias($config['provider'], true));
+        $container->setAlias('fos_message.participant_provider', new Alias($config['participant_provider'], true));
+        $container->setAlias('fos_message.authorizer', new Alias($config['authorizer'], true));
+        $container->setAlias('fos_message.message_reader', new Alias($config['message_reader'], true));
+        $container->setAlias('fos_message.thread_reader', new Alias($config['thread_reader'], true));
+        $container->setAlias('fos_message.deleter', new Alias($config['deleter'], true));
+        $container->setAlias('fos_message.spam_detector', new Alias($config['spam_detector'], true));
+        $container->setAlias('fos_message.twig_extension', new Alias($config['twig_extension'], true));
 
         // BC management
         $newThreadFormType = $config['new_thread_form']['type'];
@@ -78,13 +79,13 @@ class FOSMessageExtension extends Extension
                 ->replaceArgument(1, $replyFormType);
         }
 
-        $container->setAlias('fos_message.new_thread_form.factory', $config['new_thread_form']['factory']);
-        $container->setAlias('fos_message.new_thread_form.handler', $config['new_thread_form']['handler']);
-        $container->setAlias('fos_message.reply_form.factory', $config['reply_form']['factory']);
-        $container->setAlias('fos_message.reply_form.handler', $config['reply_form']['handler']);
+        $container->setAlias('fos_message.new_thread_form.factory', new Alias($config['new_thread_form']['factory'], true));
+        $container->setAlias('fos_message.new_thread_form.handler', new Alias($config['new_thread_form']['handler'], true));
+        $container->setAlias('fos_message.reply_form.factory', new Alias($config['reply_form']['factory'], true));
+        $container->setAlias('fos_message.reply_form.handler', new Alias($config['reply_form']['handler'], true));
 
-        $container->setAlias('fos_message.search_query_factory', $config['search']['query_factory']);
-        $container->setAlias('fos_message.search_finder', $config['search']['finder']);
+        $container->setAlias('fos_message.search_query_factory', new Alias($config['search']['query_factory'], true));
+        $container->setAlias('fos_message.search_finder', new Alias($config['search']['finder'], true));
         $container->getDefinition('fos_message.search_query_factory.default')
             ->replaceArgument(1, $config['search']['query_parameter']);
 


### PR DESCRIPTION
Modified /DependencyInjection/FOSMessageExtension.php made all \Symfony\Component\DependencyInjection\Alias(es) public.

Fixes Errors like:

> The "fos_message.provider" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.